### PR TITLE
Add mobile-friendly CSS

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -266,3 +266,14 @@ ul#timings {
     font-size: 50%;
     color: #999;
 }
+
+@media only screen and (max-width: 600px) {
+  div#content {
+    padding: 12px 12px 12px 12px;
+  }
+  div#sidebar {
+    float: none;
+    width: 80%;
+    clear: both;
+  }
+}


### PR DESCRIPTION
For https://github.com/python/docs-community/issues/7.

Apply @simonw's suggestion from https://discuss.python.org/t/wiki-python-org-is-not-mobile-friendly/8700/26

I gave Simon credit via a `Co-authored-by` trailer.

I've not tested this.
